### PR TITLE
Minor fixes

### DIFF
--- a/prose/part1/3-scavenge-design.markdown
+++ b/prose/part1/3-scavenge-design.markdown
@@ -1758,10 +1758,10 @@ findClues _    (gate _ _) = mempty
 findClues kctx (andThen c _)    = findClues kctx c
 findClues kctx (reward _) = mempty
 findClues kctx (clue k empty)
-  = singleton (kctx <> [k]) completed
+  = singleton (kctx <> k) completed
 findClues kctx (clue k c)
-  = singleton (kctx <> [k]) seen
-    <> findClues (kctx <> [k]) c
+  = singleton (kctx <> k) seen
+    <> findClues (kctx <> k) c
 ```
 
 

--- a/prose/part1/3-scavenge-design.markdown
+++ b/prose/part1/3-scavenge-design.markdown
@@ -1660,7 +1660,7 @@ state in the process.
 ```{.haskell law="step/clue/empty"}
 ∀ (kctx :: Clue) (i :: Maybe Input) (k :: Clue).
   step kctx i (clue k empty) =
-    tellClue (singleton (sub kctx k) completed) *> empty
+    tellClue (singleton (sub kctx k) completed) *> pure empty
 ```
 
 Notice the call to `sub` here. We must prepend the current `Clue`
@@ -1709,7 +1709,7 @@ of the currently accessible clues in the given `Challenge`. Armed with
   step kctx i c1 == (z1, empty) &&
   step kctx i c2 == (z2, c2') =>
     step kctx i (eitherC c1 c2) =
-      fmap seenToFailed (findClues kctx c2') *>
+      tellClue (fmap seenToFailed (findClues kctx c2')) *>
         step kctx i c2 *>
           step kctx i c1
 ```

--- a/prose/part1/3-scavenge-design.markdown
+++ b/prose/part1/3-scavenge-design.markdown
@@ -1897,7 +1897,7 @@ data Challenge i r
 reward :: r -> Challenge i r
 
 step
-    :: ( IsFilter i
+    :: ( HasFilter i
        , Monoid r
        , Commutative r
        )
@@ -1938,7 +1938,7 @@ data Challenge i r k
 clue :: [k] -> Challenge i k r -> Challenge i k r
 
 step
-    :: ( IsFilter f
+    :: ( HasFilter f
        , Monoid r
        , Commutative r
        , Ord k

--- a/prose/part2/1-tiles-impl.markdown
+++ b/prose/part2/1-tiles-impl.markdown
@@ -986,7 +986,7 @@ Again, this pair of laws is elegant, symmetric, and clearly shows why `cw . ccw
 
 
 We can think of `beside` as a spatial transformation from the coordinate space
-of `both c1 c2` (the "source") into the coordinate spaces of `c1` and `c2` (the
+of `beside c1 c2` (the "source") into the coordinate spaces of `c1` and `c2` (the
 "destinations.") The cut-off between the two tiles happens at $x = 0$, therefore for
 $x < 0$ we should choose `c1` and for $0 \leq x$ choose `c2`. Due to the
 contravariance of spatial transformations, this operation's mathematics are rather hard to visualize mentally. @Fig:beside-impl shows the `c1` case and should help.

--- a/prose/part2/1-tiles-impl.markdown
+++ b/prose/part2/1-tiles-impl.markdown
@@ -752,7 +752,7 @@ you should use a value somewhere between 7 and 9.
 quickSpec $ sig <> withPrintStyle ForQuickCheck <> withMaxTests 1000 <> withMaxTestSize 20 <> withMaxTermSize 2
 ```
 
-The resulting `laws_quickspec` can be pasted into a test module, and executed
+The resulting `quickspec_laws` can be pasted into a test module, and executed
 via:
 
 ```haskell
@@ -760,7 +760,7 @@ runTests :: IO ()
 runTests
   = traverse_
       (quickCheck . uncurry counterexample)
-      laws_quickspec
+      quickspec_laws
 ```
 
 As an added precaution, it's good form to ensure that your new tests are green

--- a/prose/part2/1-tiles-impl.markdown
+++ b/prose/part2/1-tiles-impl.markdown
@@ -987,7 +987,7 @@ Again, this pair of laws is elegant, symmetric, and clearly shows why `cw . ccw
 
 We can think of `beside` as a spatial transformation from the coordinate space
 of `both c1 c2` (the "source") into the coordinate spaces of `c1` and `c2` (the
-"destinations.") The cut-off between the two happens tiles at $x = 0$, therefore for
+"destinations.") The cut-off between the two tiles happens at $x = 0$, therefore for
 $x < 0$ we should choose `c1` and for $0 \leq x$ choose `c2`. Due to the
 contravariance of spatial transformations, this operation's mathematics are rather hard to visualize mentally. @Fig:beside-impl shows the `c1` case and should help.
 

--- a/prose/part2/1-tiles-impl.markdown
+++ b/prose/part2/1-tiles-impl.markdown
@@ -973,7 +973,7 @@ elegantly:
 ```
 
 Without the challenging `transpose` machinery that we saw in `law:sample/cw`, we
-can specify `ccw` directly, without needing to relegate to `law:ccw`:
+can specify `ccw` directly, without needing to relegate to `law:ccw/cw`:
 
 ```{.haskell law="sample/ccw"}
 ∀ (t :: Tile a) (x :: Double) (y :: Double).

--- a/prose/part2/2-scavenge-impl.markdown
+++ b/prose/part2/2-scavenge-impl.markdown
@@ -205,7 +205,7 @@ One particular annoyance when working with initial encodings is having two
 terminal constructors which behave similarly --- in our case `empty` and
 `reward` both immediately reduce to `empty`, but all of our `step` laws are in
 terms of `isEmpty`. Rather than dealing with double logic everywhere, we can
-instead use `law:andThen/empty` to rewrite `reward r` as `andThen (reward r)
+instead use `law:andThen:identity` to rewrite `reward r` as `andThen (reward r)
 empty`. In this form, `reward r` no longer acts as a terminal constructor, so
 we can use `andThen (reward r)` as a primitive form:
 
@@ -220,7 +220,7 @@ which we can use to give an implementation for `reward` as follows:
 
 ```{.haskell .proof}
   reward r
-=  -- .via andThen/empty
+=  -- .via andThen:identity
   andThen (reward r) empty
 =  -- .via RewardThen
   RewardThen r empty


### PR DESCRIPTION
I'm not 100% sure about the second one, but the types didn't seem to align: AFAIK `fmap f x *> a` has to discard the result of `f`